### PR TITLE
github API and reading directly from Google sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 docs/_build/*
+credentials.json
+token.*
+.ipynb_checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ docs/_build/*
 credentials.json
 token.*
 .ipynb_checkpoints/
+__pycache__/
+*.py[cod]
+*$py.class

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division

--- a/scripts/make-gh-issues.py
+++ b/scripts/make-gh-issues.py
@@ -1,0 +1,31 @@
+"""
+requires the "PyGitHub" package (`pip install pygithub`).
+You can leave out things like an assignee, a label etc., by simply leaving them out of the code.
+"""
+
+
+from github import Github
+import os
+from pprint import pprint
+import configparser
+from utils import read_google_sheets
+
+df = read_google_sheets(credentials_file='../credentials.json', sheet_id='1Us-stsbBJ3XgsIPi0iIm1u5FyJPFGVgc993ppzQUBik', sheet_range='A1:g1000')
+
+config = configparser.ConfigParser()
+config.read('../token.config')
+token = config['GitHub-api']['token']
+
+client = Github(token)
+repo = client.get_repo("snowex-hackweek/administrative")
+for i in range(len(df)):
+    issue = repo.create_issue(
+        title=df['title'][i],
+        body=df['body'][i],
+        assignee=df['assignee'][i],
+        labels=[
+            repo.get_label(df["label-1"][i]), repo.get_label(df["label-2"][i]), repo.get_label(df["label-3"][i])
+        ]
+    )
+
+pprint(issue)

--- a/scripts/make-gh-issues.py
+++ b/scripts/make-gh-issues.py
@@ -1,8 +1,4 @@
-"""
-requires the "PyGitHub" package (`pip install pygithub`).
-You can leave out things like an assignee, a label etc., by simply leaving them out of the code.
-"""
-
+# uses PyGitHub (https://pygithub.readthedocs.io/)
 
 from github import Github
 import os
@@ -10,7 +6,7 @@ from pprint import pprint
 import configparser
 from utils import read_google_sheets
 
-df = read_google_sheets(credentials_file='../credentials.json', sheet_id='1Us-stsbBJ3XgsIPi0iIm1u5FyJPFGVgc993ppzQUBik', sheet_range='A1:g1000')
+df = read_google_sheets(credentials_file='../credentials.json', sheet_id='1Us-stsbBJ3XgsIPi0iIm1u5FyJPFGVgc993ppzQUBik', sheet_range='new!A1:g1000')
 
 config = configparser.ConfigParser()
 config.read('../token.config')
@@ -18,13 +14,20 @@ token = config['GitHub-api']['token']
 
 client = Github(token)
 repo = client.get_repo("snowex-hackweek/administrative")
+
+open_milestones = repo.get_milestones(state='open')
+ms_dict = {}
+for milestone in open_milestones:
+    ms_dict[milestone.title] = milestone.number
+    
 for i in range(len(df)):
     issue = repo.create_issue(
         title=df['title'][i],
         body=df['body'][i],
         assignee=df['assignee'][i],
+        milestone=repo.get_milestone(number = ms_dict[df['milestone'][i]]),
         labels=[
-            repo.get_label(df["label-1"][i]), repo.get_label(df["label-2"][i]), repo.get_label(df["label-3"][i])
+            repo.get_label(df["label"][i])
         ]
     )
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,68 @@
+def read_google_sheets(credentials_file=None, sheet_id=None, sheet_range=None):
+    """
+
+    code to read data directly from google sheets
+
+    using instructions from https://medium.com/analytics-vidhya/how-to-read-and-write-data-to-google-spreadsheet-using-python-ebf54d51a72c
+
+    Parameters
+    ----------
+
+        credentials_file : string
+            The filename of the credentials file acquired from the Google API
+        sheet_id : string
+            The object identifier of the spreadsheet you want to read, taken from the link generated when sharing a file
+        range : string
+            The spreadsheet range
+
+    Returns 
+    -------
+
+        df: data frame
+
+    """
+
+    import pandas as pd
+    from googleapiclient.discovery import build
+    from google_auth_oauthlib.flow import InstalledAppFlow,Flow
+    from google.auth.transport.requests import Request
+    import os
+    import pickle
+
+    SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+
+    # here enter the id of your google sheet
+    SAMPLE_SPREADSHEET_ID_input = sheet_id
+    SAMPLE_RANGE_NAME = sheet_range
+
+    def main():
+        global values_input, service
+        creds = None
+        if os.path.exists('token.pickle'):
+            with open('token.pickle', 'rb') as token:
+                creds = pickle.load(token)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    credentials_file, SCOPES) # here enter the name of your downloaded JSON file
+                creds = flow.run_local_server(port=0)
+            with open('token.pickle', 'wb') as token:
+                pickle.dump(creds, token)
+
+        service = build('sheets', 'v4', credentials=creds)
+
+        # Call the Sheets API
+        sheet = service.spreadsheets()
+        result_input = sheet.values().get(spreadsheetId=SAMPLE_SPREADSHEET_ID_input,
+                                    range=SAMPLE_RANGE_NAME).execute()
+        values_input = result_input.get('values', [])
+
+        if not values_input and not values_expansion:
+            print('No data found.')
+
+    main()
+
+    df=pd.DataFrame(values_input[1:], columns=values_input[0])
+    return df


### PR DESCRIPTION
This PR adds scripts that run the GitHub API to autogenerate issues from a Google spreadsheet. We can use these issues to track tasks associated with running a hackweek.